### PR TITLE
Support `import from` syntax of es6 module

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function customize (customOptions) {
         extend(empowerOptions, options.assertion)
     );
     poweredAssert.customize = customize;
+    poweredAssert.default = poweredAssert;
     return poweredAssert;
 }
 

--- a/index.js
+++ b/index.js
@@ -26,8 +26,9 @@ function customize (customOptions) {
         extend(empowerOptions, options.assertion)
     );
     poweredAssert.customize = customize;
-    poweredAssert.default = poweredAssert;
     return poweredAssert;
 }
 
-module.exports = customize();
+var defaultAssert = customize();
+defaultAssert.default = defaultAssert;
+module.exports = defaultAssert;


### PR DESCRIPTION
expected

```ts
// es6
import assert from 'power-assert';
import * as assert from 'power-assert';
// es5
var assert = require('power-assert');
```

actual

```ts
// es6
import * as assert from 'power-assert';
// es5
var assert = require('power-assert');
```