### PR TITLE
Access property `default` using bracket notation

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,5 +32,5 @@ function customize (customOptions) {
 
 var defaultAssert = customize();
 define(defaultAssert, { '__esModule': true });
-defaultAssert.default = defaultAssert;
+defaultAssert['default'] = defaultAssert;
 module.exports = defaultAssert;


### PR DESCRIPTION
Using dot notation to access the property `default` causes an error in Internet Explorer 8:
```
Expected identifier
~/power-assert/index.js:35:0
```
because `default` is a reserved word.
Similar errors:
http://stackoverflow.com/a/14448965
http://stackoverflow.com/a/32780767
