### PR TITLE
feat(assert): use `core-assert` in browser field (fix #45)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     }
   ],
   "dependencies": {
+    "core-assert": "^0.2.0",
     "define-properties": "^1.1.2",
     "empower": "^1.1.0",
     "power-assert-formatter": "^1.3.1",
@@ -78,6 +79,9 @@
   ],
   "license": "MIT",
   "main": "./index.js",
+  "browser": {
+    "assert": "core-assert"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/power-assert-js/power-assert.git"


### PR DESCRIPTION
> [replace specific files - advanced / defunctzombie/package-browser-field-spec](https://github.com/defunctzombie/package-browser-field-spec\#replace-specific-files---advanced)

that redefines the polyfill function, enable use the `deepStrictEqual`! 👍 
