### PR TITLE
Integrate universal-deep-strict-equal to enable `deepStrictEqual` on browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 'use strict';
 
 var baseAssert = require('assert');
+var _deepEqual = require('universal-deep-strict-equal');
 var empower = require('empower');
 var formatter = require('power-assert-formatter');
 var extend = require('xtend');
@@ -18,6 +19,21 @@ var empowerOptions = {
     modifyMessageOnRethrow: true,
     saveContextOnRethrow: true
 };
+
+if (typeof baseAssert.deepStrictEqual !== 'function') {
+    baseAssert.deepStrictEqual = function deepStrictEqual (actual, expected, message) {
+        if (!_deepEqual(actual, expected, true)) {
+            baseAssert.fail(actual, expected, message, 'deepStrictEqual', deepStrictEqual);
+        }
+    };
+}
+if (typeof baseAssert.notDeepStrictEqual !== 'function') {
+    baseAssert.notDeepStrictEqual = function notDeepStrictEqual (actual, expected, message) {
+        if (_deepEqual(actual, expected, true)) {
+            baseAssert.fail(actual, expected, message, 'notDeepStrictEqual', notDeepStrictEqual);
+        }
+    };
+}
 
 function customize (customOptions) {
     var options = customOptions || {};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "define-properties": "^1.1.2",
     "empower": "^1.1.0",
     "power-assert-formatter": "^1.3.1",
+    "universal-deep-strict-equal": "^1.1.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/tobe_instrumented/assertion.js
+++ b/test/tobe_instrumented/assertion.js
@@ -860,6 +860,18 @@ describe('power-assert message', function () {
     });
 
 
+    it('deepStrictEqual', function () {
+        this.expectPowerAssertMessage(function () {
+            assert.deepStrictEqual({a:1}, {a:'1'});
+        },[
+            '  assert.deepStrictEqual({ a: 1 }, { a: \'1\' })',
+            '                         |         |          ',
+            '                         |         Object{a:\"1\"}',
+            '                         Object{a:1}          '
+        ]);
+    });
+
+
     it('ObjectExpression with Literals', function () {
         this.expectPowerAssertMessage(function () {
             assert.deepEqual({ foo: 0 }, { foo: 1 });


### PR DESCRIPTION
Integrate [universal-deep-strict-equal](https://github.com/twada/universal-deep-strict-equal) to enable `deepStrictEqual` on browsers.

fixes #45 
alternative to #47 