### PR TITLE
test(power-assert): fix errors of karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,9 @@
 module.exports = function (config) {
     config.set({
         basePath: '',
+        client: {
+            useIframe: false
+        },
         frameworks: ['mocha', 'expect'],
         files: [
             { pattern: 'node_modules/requirejs/require.js', included: false },


### PR DESCRIPTION
Sometimes karma tests fail with `Some of your tests did a full page reload!`.

https://travis-ci.org/twada/power-assert-keeper/jobs/128800585#L1045

It is probably caused by the unload event in iframes. Karma watches iframes by default. So I ignore iframes.
