### PR TITLE
Fix deepStrictEqual usage to run with old Node (v0.12)

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,14 +23,14 @@ var empowerOptions = {
 if (typeof baseAssert.deepStrictEqual !== 'function') {
     baseAssert.deepStrictEqual = function deepStrictEqual (actual, expected, message) {
         if (!_deepEqual(actual, expected, true)) {
-            baseAssert.fail(actual, expected, message, 'deepStrictEqual', deepStrictEqual);
+            baseAssert.fail(actual, expected, message, 'deepStrictEqual');
         }
     };
 }
 if (typeof baseAssert.notDeepStrictEqual !== 'function') {
     baseAssert.notDeepStrictEqual = function notDeepStrictEqual (actual, expected, message) {
         if (_deepEqual(actual, expected, true)) {
-            baseAssert.fail(actual, expected, message, 'notDeepStrictEqual', notDeepStrictEqual);
+            baseAssert.fail(actual, expected, message, 'notDeepStrictEqual');
         }
     };
 }


### PR DESCRIPTION
Omit 5th argument (`stackStartFunction`) since it causes `ReferenceError` under some conditions.

- Node v0.12.x
- babel-register 6.18.0
- power-assert 1.4.1
- mocha 3.1.2

Reproduction case -> [twada/power-assert-deep-strict-equal-reference-error-repro: power-assert 1.4.1 under Node v0.12.x and Babel6 bug reproduction](https://github.com/twada/power-assert-deep-strict-equal-reference-error-repro)

Note: this PR only affects to Node v0.12.