### PR TITLE
Support policy of Node versions and various browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      node_js: "0.10"
-    - os: linux
-      dist: trusty
-      sudo: required
-      node_js: "0.12"
-    - os: linux
-      dist: trusty
-      sudo: required
       node_js: "4"
     - os: linux
       dist: trusty
@@ -24,6 +16,10 @@ matrix:
     - os: osx
       osx_image: xcode8
       node_js: "6"
+    - os: linux
+      dist: trusty
+      sudo: required
+      node_js: "7"
 addons:
   firefox: latest
   apt:

--- a/README.md
+++ b/README.md
@@ -664,6 +664,16 @@ SUPPORTED FRAMEWORKS
 * [Lab](https://github.com/hapijs/lab)
 
 
+OUR SUPPORT POLICY
+---------------------------------------
+
+For the Transpiler side, we support Node under maintenance. In other words, we stop supporting old Node version when [their maintenance ends](https://github.com/nodejs/LTS).
+
+For the Runtime side, we support [Node under maintenance](https://github.com/nodejs/LTS) and "modern enough" browsers such as Chrome, Firefox, Safari, Edge etc.
+
+Any other environments are not supported officially (means that we do not test against them on CI service). power-assert is known to work with old browsers, and trying to keep them working though.
+
+
 AUTHOR
 ---------------------------------------
 * [Takuto Wada](https://github.com/twada)


### PR DESCRIPTION
fixes #72

OUR SUPPORT POLICY
---------------------------------------

For the Transpiler side, we support Node under maintenance. In other words, we stop supporting old Node version when [their maintenance ends](https://github.com/nodejs/LTS).

For the Runtime side, we support [Node under maintenance](https://github.com/nodejs/LTS) and "modern enough" browsers such as Chrome, Firefox, Safari, Edge etc.

Any other environments are not supported officially (means that we do not test against them on CI service). power-assert is known to work with old browsers, and trying to keep them working though.