### PR TITLE
Update empower to 1.2.2 for Node v8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ matrix:
       dist: trusty
       sudo: required
       node_js: "7"
+    - os: linux
+      dist: trusty
+      sudo: required
+      node_js: "8"
 addons:
   firefox: latest
   apt:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "define-properties": "^1.1.2",
-    "empower": "^1.1.0",
+    "empower": "^1.2.2",
     "power-assert-formatter": "^1.3.1",
     "universal-deep-strict-equal": "^1.2.1",
     "xtend": "^4.0.0"

--- a/test/not_tobe_instrumented/not_instrumented.js
+++ b/test/not_tobe_instrumented/not_instrumented.js
@@ -10,7 +10,7 @@ describe('power-assert client should work with not-instrumented code', function 
                 body();
                 expect().fail("AssertionError should be thrown");
             } catch (e) {
-                expect(e.name).to.be('AssertionError');
+                expect(e.name).to.match(/^AssertionError/);
                 expect(e.message).to.be('plain assertion message');
             }
         };


### PR DESCRIPTION
To deal with `err.name` on Node v8
since Node v8's err.name contains error code like `AssertionError [ERR_ASSERTION]`