### PR TITLE
 feat: support "Strict mode"

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var baseAssert = require('assert');
 var _deepEqual = require('universal-deep-strict-equal');
 var empower = require('empower');
 var formatter = require('power-assert-formatter');
-var extend = require('xtend');
+var assign = require('xtend/mutable');
 var define = require('define-properties');
 var empowerOptions = {
     modifyMessageOnRethrow: true,
@@ -37,17 +37,21 @@ if (typeof baseAssert.notDeepStrictEqual !== 'function') {
 
 function customize (customOptions) {
     var options = customOptions || {};
-    var poweredAssert = empower(
-        baseAssert,
-        formatter(options.output),
-        extend(empowerOptions, options.assertion)
-    );
+    var applyEmpower = function (fn) {
+        return empower(
+            fn,
+            formatter(options.output),
+            assign({}, empowerOptions, options.assertion)
+        );
+    };
+    var poweredAssert = applyEmpower(baseAssert);
     poweredAssert.customize = customize;
-    poweredAssert.strict = extend(poweredAssert, {
-        equal: poweredAssert.strictEqual,
-        deepEqual: poweredAssert.deepStrictEqual,
-        notEqual: poweredAssert.notStrictEqual,
-        notDeepEqual: poweredAssert.notDeepStrictEqual
+    var strict = applyEmpower(baseAssert);
+    poweredAssert.strict = assign(strict, {
+        equal: strict.strictEqual,
+        deepEqual: strict.deepStrictEqual,
+        notEqual: strict.notStrictEqual,
+        notDeepEqual: strict.notDeepStrictEqual
     });
     return poweredAssert;
 }

--- a/index.js
+++ b/index.js
@@ -54,10 +54,10 @@ function customize (customOptions) {
             equal: strict.strictEqual,
             deepEqual: strict.deepStrictEqual,
             notEqual: strict.notStrictEqual,
-            notDeepEqual: strict.notDeepStrictEqual,
-            strict: strict
+            notDeepEqual: strict.notDeepStrictEqual
         });
     }
+    poweredAssert.strict.strict = poweredAssert.strict;
     return poweredAssert;
 }
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ function customize (customOptions) {
             equal: strict.strictEqual,
             deepEqual: strict.deepStrictEqual,
             notEqual: strict.notStrictEqual,
-            notDeepEqual: strict.notDeepStrictEqual
+            notDeepEqual: strict.notDeepStrictEqual,
+            strict: strict
         });
     }
     return poweredAssert;

--- a/index.js
+++ b/index.js
@@ -46,13 +46,17 @@ function customize (customOptions) {
     };
     var poweredAssert = applyEmpower(baseAssert);
     poweredAssert.customize = customize;
-    var strict = applyEmpower(baseAssert);
-    poweredAssert.strict = assign(strict, {
-        equal: strict.strictEqual,
-        deepEqual: strict.deepStrictEqual,
-        notEqual: strict.notStrictEqual,
-        notDeepEqual: strict.notDeepStrictEqual
-    });
+    if (typeof baseAssert.strict === 'function') {
+        poweredAssert.strict = applyEmpower(baseAssert.strict);
+    } else {
+        var strict = applyEmpower(baseAssert);
+        poweredAssert.strict = assign(strict, {
+            equal: strict.strictEqual,
+            deepEqual: strict.deepStrictEqual,
+            notEqual: strict.notStrictEqual,
+            notDeepEqual: strict.notDeepStrictEqual
+        });
+    }
     return poweredAssert;
 }
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,12 @@ function customize (customOptions) {
         extend(empowerOptions, options.assertion)
     );
     poweredAssert.customize = customize;
+    poweredAssert.strict = extend(poweredAssert, {
+        equal: poweredAssert.strictEqual,
+        deepEqual: poweredAssert.deepStrictEqual,
+        notEqual: poweredAssert.notStrictEqual,
+        notDeepEqual: poweredAssert.notDeepStrictEqual
+    });
     return poweredAssert;
 }
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = function (config) {
             { pattern: 'espowered_tests/tobe_instrumented/assertion.js', watched: true, served: true, included: true },
             { pattern: 'espowered_tests/tobe_instrumented/assertion.es6.js', watched: true, served: true, included: true },
             { pattern: 'espowered_tests/tobe_instrumented/customization.js', watched: true, served: true, included: true },
+            { pattern: 'espowered_tests/tobe_instrumented/strict_mode.js', watched: true, served: true, included: true },
             { pattern: 'espowered_tests/not_tobe_instrumented/not_instrumented.js', watched: true, served: true, included: true },
             { pattern: 'espowered_tests/tobe_instrumented/modules.js', watched: true, served: true, included: true }
         ],

--- a/test/tobe_instrumented/strict_mode.js
+++ b/test/tobe_instrumented/strict_mode.js
@@ -1,0 +1,52 @@
+if (typeof window === 'undefined') {
+    var expect = require('expect.js');
+    var assert = require('../..');
+}
+
+describe('strict mode support', function () {
+
+    var legacyModeAssert = assert;
+
+    beforeEach(function () {
+        assert = assert.strict;
+    });
+    afterEach(function () {
+        assert = legacyModeAssert;
+    });
+
+    function expectPowerAssertMessage (body, expectedLines) {
+        try {
+            body();
+            expect().fail("AssertionError should be thrown");
+        } catch (e) {
+            if (e.message === 'AssertionError should be thrown') {
+                throw e;
+            }
+            expect(e.message.split('\n').slice(2, -1)).to.eql(expectedLines);
+        }
+    };
+
+    it('equal becomes strictEqual', function () {
+        var three = 3, threeInStr = '3';
+        expectPowerAssertMessage(function () {
+            assert.equal(three, threeInStr);
+        },[
+            '  assert.equal(three, threeInStr)',
+            '               |      |          ',
+            '               3      "3"        '
+        ]);
+    });
+
+    it('deepEqual becomes deepStrictEqual', function () {
+        var three = 3, threeInStr = '3';
+        expectPowerAssertMessage(function () {
+            assert.deepEqual({a: three}, {a: threeInStr});
+        },[
+            '  assert.deepEqual({ a: three }, { a: threeInStr })',
+            '                   |    |        |    |            ',
+            '                   |    |        |    "3"          ',
+            '                   |    3        Object{a:"3"}     ',
+            '                   Object{a:3}                     '
+        ]);
+    });
+});

--- a/test/tobe_instrumented/strict_mode.js
+++ b/test/tobe_instrumented/strict_mode.js
@@ -71,4 +71,13 @@ describe('strict mode support', function () {
             '                   Object{a:3}                     '
         ]);
     });
+
+    it('structural compatibility between strict mode and legacy mode', function () {
+        var legacyModeProps = Object.keys(legacyModeAssert);
+        expect(legacyModeProps.length).to.be.above(0);
+        legacyModeProps.every(function (name) {
+            expect(assert).to.have.property(name);
+            expect(typeof assert[name]).to.be.equal(typeof legacyModeAssert[name]);
+        });
+    });
 });

--- a/test/tobe_instrumented/strict_mode.js
+++ b/test/tobe_instrumented/strict_mode.js
@@ -26,6 +26,10 @@ describe('strict mode support', function () {
         }
     };
 
+    it('`strict` mode assert should also have `strict` property', function () {
+        expect(typeof assert.strict).to.equal('function');
+    });
+
     it('`strict` mode assert should also be a function', function () {
         var foo = 'foo', bar = 8;
         expectPowerAssertMessage(function () {

--- a/test/tobe_instrumented/strict_mode.js
+++ b/test/tobe_instrumented/strict_mode.js
@@ -30,6 +30,11 @@ describe('strict mode support', function () {
         expect(typeof assert.strict).to.equal('function');
     });
 
+    it('`strict` property of strict mode assert should also be an empowered one', function () {
+        // `_empowered` is a hidden property to determine whether target function is already empowered or not.
+        expect(assert.strict._empowered).to.equal(true);
+    });
+
     it('`strict` mode assert should also be a function', function () {
         var foo = 'foo', bar = 8;
         expectPowerAssertMessage(function () {

--- a/test/tobe_instrumented/strict_mode.js
+++ b/test/tobe_instrumented/strict_mode.js
@@ -26,6 +26,24 @@ describe('strict mode support', function () {
         }
     };
 
+    it('`strict` mode assert should also be a function', function () {
+        var foo = 'foo', bar = 8;
+        expectPowerAssertMessage(function () {
+            assert(foo === bar);
+        }, [
+            '  assert(foo === bar)',
+            '         |   |   |   ',
+            '         |   |   8   ',
+            '         |   false   ',
+            '         "foo"       ',
+            '  ',
+            '  [number] bar',
+            '  => 8',
+            '  [string] foo',
+            '  => "foo"'
+        ]);
+    });
+
     it('equal becomes strictEqual', function () {
         var three = 3, threeInStr = '3';
         expectPowerAssertMessage(function () {


### PR DESCRIPTION
Support (i.e backport) ["strict mode"](https://nodejs.org/api/assert.html#assert_strict_mode) introduced in Node9.

> When using the strict mode, any assert function will use the equality used in the strict function mode. So assert.deepEqual() will, for example, work the same as assert.deepStrictEqual().
> 
> ["Strict mode"](https://nodejs.org/api/assert.html#assert_strict_mode)

refs: #103 